### PR TITLE
Python 3 compatibility in version.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -66,12 +66,14 @@ def readGitVersion():
                                  '--match', 'v[0-9]*.*'),
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         data, _ = proc.communicate()
+        data = data.decode('utf-8')
         if proc.returncode:
             return None
         ver = data.splitlines()[0].strip()
         proc = subprocess.Popen(('git', 'rev-parse', '--abbrev-ref', 'HEAD'),
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         branch, _ = proc.communicate()
+        branch = branch.decode('utf-8')
         if proc.returncode:
             return None
     except:
@@ -131,5 +133,4 @@ def getVersion():
 
 
 if __name__ == '__main__':
-    print getVersion()
-
+    print(getVersion())


### PR DESCRIPTION
Thanks for making si-prefix, I'm using it with python3 and it works great! :)

This:
```
pip3 install si_prefix
```

Doesn't work, so I added python3 style prints and decodes. This works for me now:

```
si-prefix $ python version.py
0.4.post11
si-prefix $ python3 version.py
0.4.post11
si-prefix $ python pavement.py
si-prefix $ python3 pavement.py
```
```
si-prefix $ python -m paver generate_setup
---> paver.misctasks.generate_setup
Write setup.py
si-prefix $ python setup.py
```

```
si-prefix $ python3 -m paver generate_setup
---> paver.misctasks.generate_setup
Write setup.py
si-prefix $ python3 setup.py
```

```
PS [...]\si-prefix> pip3 install ./
Processing  [...]\si-prefix
Building wheels for collected packages: si-prefix
  Running setup.py bdist_wheel for si-prefix ... done
  Stored in directory:  [...]
Successfully built si-prefix
Installing collected packages: si-prefix
Successfully installed si-prefix-0.4.post11
```