### PR TITLE
cleanup and add "trailing_zeroes" argument to si_format()

### DIFF
--- a/si_prefix/__init__.py
+++ b/si_prefix/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import math
 import re
+from __future__ import division
 
 from ._version import get_versions
 
@@ -249,7 +250,7 @@ def si_parse(value):
                                 r'(?P<expof10>[+\-]?\d+))?$')
     CRE_SI_NUMBER = re.compile(r'^\s*(?P<number>(?P<integer>[+\-]?\d+)?'
                                r'(?P<fraction>.\d+)?)\s*'
-                               u'(?P<si_unit>[' + SI_PREFIX_UNITS + r'])?\s*$')
+                               r'(?P<si_unit>[' + SI_PREFIX_UNITS + r'])?\s*$')
     match = CRE_10E_NUMBER.match(value)
     if match:
         # Can be parse using `float`.

--- a/si_prefix/__init__.py
+++ b/si_prefix/__init__.py
@@ -32,7 +32,6 @@ del get_versions
 #: .. _`The International System of Units (SI) report`: https://www.bipm.org/utils/common/pdf/si_brochure_8_en.pdf
 SI_PREFIX_UNITS = u"yzafpnµm kMGTPEZY"
 
-
 #: .. versionchanged:: 1.0
 #:     Use unicode string for SI unit to support micro (i.e., µ) character.
 #:
@@ -41,6 +40,9 @@ SI_PREFIX_UNITS = u"yzafpnµm kMGTPEZY"
 #:         `Issue #4`_.
 #:
 #: .. _`Issue #4`: https://github.com/cfobel/si-prefix/issues/4
+CRE_SI_NUMBER = re.compile(r'^\s*(?P<number>(?P<integer>[+\-]?\d+)?'
+                           r'(?P<fraction>.\d+)?)\s*'
+                           r'(?P<si_unit>[' + SI_PREFIX_UNITS + r'])?\s*$')
 
 
 def split(value, precision=1):
@@ -145,7 +147,7 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
         respectively.  This format is used if the absolute exponent of 10 value
         is greater than 24.
     trailing_zeroes : bool
-        Include trailing zeroes if number of decimals in value is less than ``{precision}``
+        Include trailing zeroes if number of decimals in value is less than the precision
 
     Returns
     -------
@@ -206,7 +208,7 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
 
     .. _`Issue #4`: https://github.com/cfobel/si-prefix/issues/4
     .. _SI prefix style:
-        httpS://physics.nist.gov/cuu/Units/checklist.html
+        https://physics.nist.gov/cuu/Units/checklist.html
     """
     svalue, expof10 = split(value, precision)
     if trailing_zeroes:
@@ -248,9 +250,7 @@ def si_parse(value):
     CRE_10E_NUMBER = re.compile(r'^\s*(?P<integer>[+\-]?\d+)?'
                                 r'(?P<fraction>.\d+)?\s*([eE]\s*'
                                 r'(?P<expof10>[+\-]?\d+))?$')
-    CRE_SI_NUMBER = re.compile(r'^\s*(?P<number>(?P<integer>[+\-]?\d+)?'
-                               r'(?P<fraction>.\d+)?)\s*'
-                               r'(?P<si_unit>[' + SI_PREFIX_UNITS + r'])?\s*$')
+
     match = CRE_10E_NUMBER.match(value)
     if match:
         # Can be parse using `float`.

--- a/si_prefix/__init__.py
+++ b/si_prefix/__init__.py
@@ -124,7 +124,7 @@ def prefix(expof10):
 
 
 def si_format(value, precision=1, format_str=u'{value} {prefix}',
-              exp_format_str=u'{value}e{expof10}'):
+              exp_format_str=u'{value}e{expof10}', trailing_zeroes=False):
     """
     Format value to string with SI prefix, using the specified precision.
 
@@ -143,6 +143,8 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
         exponent of 10 and the value (scaled according to the exponent of 10),
         respectively.  This format is used if the absolute exponent of 10 value
         is greater than 24.
+    trailing_zeroes : bool
+        Include trailing zeroes if number of decimals in value is less than ``{precision}``
 
     Returns
     -------
@@ -206,17 +208,20 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
         httpS://physics.nist.gov/cuu/Units/checklist.html
     """
     svalue, expof10 = split(value, precision)
-    value_format = u'%%.%df' % precision
-    value_str = value_format % svalue
+    if trailing_zeroes:
+        value_str = f"{svalue:.{precision}f}"
+    else:
+        # rounds to precision without trailing zeroes which drives me insane
+        value_str = f"{round(svalue, precision):g}"
     try:
         return format_str.format(value=value_str,
-                                 prefix=prefix(expof10).strip())
+                                 prefix=prefix(expof10).strip()).strip()
     except ValueError:
         sign = ''
         if expof10 > 0:
             sign = "+"
         return exp_format_str.format(value=value_str,
-                                     expof10=''.join([sign, str(expof10)]))
+                                     expof10=''.join([sign, str(expof10)])).strip()
 
 
 def si_parse(value):

--- a/si_prefix/__init__.py
+++ b/si_prefix/__init__.py
@@ -1,9 +1,9 @@
 # coding: utf-8
-from __future__ import division
 import math
 import re
 
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
 
@@ -30,6 +30,8 @@ del get_versions
 #: .. _`Forum post`: https://mail.python.org/pipermail/python-list/2009-February/525913.html
 #: .. _`The International System of Units (SI) report`: https://www.bipm.org/utils/common/pdf/si_brochure_8_en.pdf
 SI_PREFIX_UNITS = u"yzafpnµm kMGTPEZY"
+
+
 #: .. versionchanged:: 1.0
 #:     Use unicode string for SI unit to support micro (i.e., µ) character.
 #:
@@ -38,14 +40,10 @@ SI_PREFIX_UNITS = u"yzafpnµm kMGTPEZY"
 #:         `Issue #4`_.
 #:
 #: .. _`Issue #4`: https://github.com/cfobel/si-prefix/issues/4
-CRE_SI_NUMBER = re.compile(r'\s*(?P<sign>[\+\-])?'
-                           r'(?P<integer>\d+)'
-                           r'(?P<fraction>.\d+)?\s*'
-                           u'(?P<si_unit>[%s])?\s*' % SI_PREFIX_UNITS)
 
 
 def split(value, precision=1):
-    '''
+    """
     Split `value` into value and "exponent-of-10", where "exponent-of-10" is a
     multiple of 3.  This corresponds to SI prefixes.
 
@@ -74,7 +72,7 @@ def split(value, precision=1):
         si_prefix.split(4781.123)  ->  (4.8, 3)
 
     See :func:`si_format` for more examples.
-    '''
+    """
     negative = False
     digits = precision + 1
 
@@ -107,7 +105,7 @@ def split(value, precision=1):
 
 
 def prefix(expof10):
-    '''
+    """
     Args:
 
         expof10 : Exponent of a power of 10 associated with a SI unit
@@ -116,7 +114,7 @@ def prefix(expof10):
     Returns:
 
         str : One of the characters in "yzafpnum kMGTPEZY".
-    '''
+    """
     prefix_levels = (len(SI_PREFIX_UNITS) - 1) // 2
     si_level = expof10 // 3
 
@@ -127,7 +125,7 @@ def prefix(expof10):
 
 def si_format(value, precision=1, format_str=u'{value} {prefix}',
               exp_format_str=u'{value}e{expof10}'):
-    '''
+    """
     Format value to string with SI prefix, using the specified precision.
 
     Parameters
@@ -136,11 +134,11 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
         Input value.
     precision : int
         Number of digits after decimal place to include.
-    format_str : str or unicode
+    exp_format_str : str or unicode
         Format string where ``{prefix}`` and ``{value}`` represent the SI
         prefix and the value (scaled according to the prefix), respectively.
         The default format matches the `SI prefix style`_ format.
-    exp_str : str or unicode
+    format_str : str or unicode
         Format string where ``{expof10}`` and ``{value}`` represent the
         exponent of 10 and the value (scaled according to the exponent of 10),
         respectively.  This format is used if the absolute exponent of 10 value
@@ -205,8 +203,8 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
 
     .. _`Issue #4`: https://github.com/cfobel/si-prefix/issues/4
     .. _SI prefix style:
-        http://physics.nist.gov/cuu/Units/checklist.html
-    '''
+        httpS://physics.nist.gov/cuu/Units/checklist.html
+    """
     svalue, expof10 = split(value, precision)
     value_format = u'%%.%df' % precision
     value_str = value_format % svalue
@@ -222,7 +220,7 @@ def si_format(value, precision=1, format_str=u'{value} {prefix}',
 
 
 def si_parse(value):
-    '''
+    """
     Parse a value expressed using SI prefix units to a floating point number.
 
     Parameters
@@ -240,22 +238,22 @@ def si_parse(value):
             `Issue #4`_.
 
     .. _`Issue #4`: https://github.com/cfobel/si-prefix/issues/4
-    '''
-    CRE_10E_NUMBER = re.compile(r'^\s*(?P<integer>[\+\-]?\d+)?'
+    """
+    CRE_10E_NUMBER = re.compile(r'^\s*(?P<integer>[+\-]?\d+)?'
                                 r'(?P<fraction>.\d+)?\s*([eE]\s*'
-                                r'(?P<expof10>[\+\-]?\d+))?$')
-    CRE_SI_NUMBER = re.compile(r'^\s*(?P<number>(?P<integer>[\+\-]?\d+)?'
+                                r'(?P<expof10>[+\-]?\d+))?$')
+    CRE_SI_NUMBER = re.compile(r'^\s*(?P<number>(?P<integer>[+\-]?\d+)?'
                                r'(?P<fraction>.\d+)?)\s*'
-                               u'(?P<si_unit>[%s])?\s*$' % SI_PREFIX_UNITS)
+                               u'(?P<si_unit>[' + SI_PREFIX_UNITS + r'])?\s*$')
     match = CRE_10E_NUMBER.match(value)
     if match:
         # Can be parse using `float`.
-        assert(match.group('integer') is not None or
-               match.group('fraction') is not None)
+        assert (match.group('integer') is not None or
+                match.group('fraction') is not None)
         return float(value)
     match = CRE_SI_NUMBER.match(value)
-    assert(match.group('integer') is not None or
-           match.group('fraction') is not None)
+    assert (match.group('integer') is not None or
+            match.group('fraction') is not None)
     d = match.groupdict()
     si_unit = d['si_unit'] if d['si_unit'] else ' '
     prefix_levels = (len(SI_PREFIX_UNITS) - 1) // 2
@@ -264,7 +262,7 @@ def si_parse(value):
 
 
 def si_prefix_scale(si_unit):
-    '''
+    """
     Parameters
     ----------
     si_unit : str
@@ -274,12 +272,12 @@ def si_prefix_scale(si_unit):
     -------
     int
         Multiple associated with `si_unit`, e.g., 1000 for `si_unit=k`.
-    '''
+    """
     return 10 ** si_prefix_expof10(si_unit)
 
 
 def si_prefix_expof10(si_unit):
-    '''
+    """
     Parameters
     ----------
     si_unit : str
@@ -290,6 +288,6 @@ def si_prefix_expof10(si_unit):
     int
         Exponent of the power of ten associated with `si_unit`, e.g., 3 for
         `si_unit=k` and -6 for `si_unit=µ`.
-    '''
+    """
     prefix_levels = (len(SI_PREFIX_UNITS) - 1) // 2
-    return (3 * (SI_PREFIX_UNITS.index(si_unit) - prefix_levels))
+    return 3 * (SI_PREFIX_UNITS.index(si_unit) - prefix_levels)

--- a/si_prefix/__init__.py
+++ b/si_prefix/__init__.py
@@ -1,7 +1,8 @@
 # coding: utf-8
+from __future__ import division
+
 import math
 import re
-from __future__ import division
 
 from ._version import get_versions
 


### PR DESCRIPTION
- some random fixes that pycharm wanted me to do
- add strip() calls to si_format(). before, if the prefix was nothing there could be a trailing space
- add trailing_zeroes argument which uses different formatting techniques to include or exclude trailing zeroes (i.e. the 0 in 1.20)