### PR TITLE
ci: remove if condition on pypi publish steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,9 @@ jobs:
           python -m build
 
       - name: Publish to TestPyPI
-        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
-        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Prior to this commit, there was an if statement on the PyPI publish steps in the `publish` job. However, the `publish` job is already being restricted to run only on releases. Therefore the `if` statement is not necessary. Morever, it looks like these PyPI publish steps were being skipped anyway; perhaps due to faulty match criteria.

In this commit, remove the `if` condition on each PyPI publish step, falling back to the `publish` job rules restricting publishing to tagged release events.