### PR TITLE
ci: remove "Publish to TestPyPI" step in `publish` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,5 @@ jobs:
         run: |
           python -m build
 
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Prior to this commit, the publish to TestPyPI results in error messages like the following:

> Trusted publishing exchange failure:
>
>
> Token request failed: the server refused the request for the following reasons:
>
> * `invalid-publisher`: valid token, but no corresponding publisher (All lookup strategies exhausted)
>
> This generally indicates a trusted publisher configuration error, but could
> also indicate an internal error on GitHub or PyPI's part.
>
>
> The claims rendered below are **for debugging purposes only**. You should **not**
> use them to configure a trusted publisher unless they already match your expectations.
>
> If a claim is not present in the claim set, then it is rendered as `MISSING`.
>
> * `sub`: `repo:cfobel/si-prefix:ref:refs/tags/v1.3.1`
> * `repository`: `cfobel/si-prefix`
> * `repository_owner`: `cfobel`
> * `repository_owner_id`: `823355`
> * `job_workflow_ref`: `cfobel/si-prefix/.github/workflows/ci.yml@refs/tags/v1.3.1`
> * `ref`: `refs/tags/v1.3.1`
>
> See https://docs.pypi.org/trusted-publishers/troubleshooting/ for more help.
>
>
>
> You're seeing this because the action wasn't given the inputs needed to
> perform password-based or token-based authentication. If you intended to
> perform one of those authentication methods instead of trusted
> publishing, then you should double-check your secret configuration and variable
> names.
>
> Read more about trusted publishers at https://docs.pypi.org/trusted-publishers/
>
> Read more about how this action uses trusted publishers at
> https://github.com/marketplace/actions/pypi-publish#trusted-publishing

In this commit, remove the TestPyPI publish step a) since it does not support trusted publishing, and b) the package is published to the main PyPI repo.